### PR TITLE
MAINT: correct readme formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ pip install jupyter_sphinx
 
 with conda:
 
-````bash
+```bash
 conda install jupyter_sphinx -c conda-forge
 ```
 


### PR DESCRIPTION
Has '`'*4, not '`'*3